### PR TITLE
fix(tsconfig.json): Change target from es5 to es6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2015",
     "noImplicitAny": false,
     "sourceMap": false,
     "rootDir": "./src",


### PR DESCRIPTION
Change target from es5 to es2015 in order to suppress the Promise warning from the typescript transpiler.